### PR TITLE
added ability to override sort order

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest_version": 3,
-  "name": "eBay item location - My country only",
-  "author": "Mountassir El Hafi : mountassirhafi@gmail.com",
-  "homepage_url": "https://github.com/mountassir/ebay-search-extention",
-  "version": "1.1.16",
+  "name": "eBay item location and delivery - My country only with sort including delivery",
+  "author": "Mountassir El Hafi : mountassirhafi@gmail.com, extended by wech71",
+  "homepage_url": "https://github.com/wech71/ebay-search-extention",
+  "version": "1.2.0",
 
-  "description": "Always start your eBay search for items in your country location only.",
+  "description": "Always start your eBay search for items in your country location only and sort by price descending including delivery.",
   "icons": {
             "16":  "icons/main/icon-16.png",
             "19":  "icons/main/icon-19.png",

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -1,17 +1,23 @@
 <html>
 <head>
-       <title>eBay item location - My country only</title>
+       <title>eBay item location - My country only and Default Sort Setting</title>
        <style>
                body: { padding: 10px; }
        </style>
 </head>
 <body style = "min-width:400px; max-width:100%;">
-	<h1>Settings</h1>
 	<form>
+		<h1>Location Settings</h1>
 		<input type="radio" id="countryOnlyRadioButton" name="type" title="This option forces eBay to only search for items in your country."> Only search for items in my country<br>
 		<input type="radio" id="regionOnlyRadioButton" name="type" title="This option forces eBay to only search for items in your continent, like European Union, North America etc."> Only search for items in my continent<br>
 		<input type="radio" id="continentalRegionOnlyRadioButton" name="type" title="This option forces eBay to only search for items in your continental region, useful for UK users who want to see items in the whole of Europe as a region."> Only search for items in my continental region<br>
 		<input type="radio" id="disableRadioButton" name="type" title="No location search override (as if this extension was not installed)."> Disable<br>
+
+		<h1>Search Settings</h1>
+		<input type="radio" id="sortOrderCheapestIncludingDeliveryRadioButton" name="sortorder" title="No sort order override (as if this extension was not installed)."> Cheapest Items including delivery first <br>
+		<input type="radio" id="sortOrderNewRadioButton" name="sortorder" title="Show New Items first."> New Items  first<br>
+		<input type="radio" id="sortOrderBestResultsRadioButton" name="sortorder" title="Show best results first."> Best Results<br>
+		<input type="radio" id="sortOrderDisableRadioButton" name="sortorder" title="No sort order override (as if this extension was not installed)."> Disable<br>
 	</form>
 
 	<h1>Donate</h1>

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -14,32 +14,62 @@ function setOverrideOption(overrideOption)
 	setWidgetChecked(overrideOption, true);
 }
 
+function setSortOverrideOption(sortOverrideOption) 
+{
+	if (!isSortOverrideOptionValid(sortOverrideOption)) 
+	{
+		sortOverrideOption = defaultSortOverride;
+
+		saveSortOverrideOptionToStorage(sortOverrideOption, function(){
+			log("Override sort option set to default: " + sortOverrideOption);
+		});
+	}
+
+	setWidgetChecked(sortOverrideOption, true);
+}
+
 function initOptions() 
 {
-	getOverrideOptionFromStorage(function(currentOverrideOption) {
+	getOverrideOptionFromStorage(function(currentOverrideOption, sortOverrideOption) {
 		setOverrideOption(currentOverrideOption);
+		setSortOverrideOption(sortOverrideOption);
 	});
 }
 
 function saveOptions()
 {
+	var modified = false;
 	let overrideOption = getSelectedOverrideOption();
+	let optionKey = {};
 
 	if(isOverrideOptionValid(overrideOption))
 	{
-		let optionKey = {};
 		optionKey[STORAGE_KEYS.OVERRIDE_OPTION] = overrideOption;
-		
-		chrome.storage.sync.set(optionKey, function() {
-			let status = document.getElementById('status');
-			status.textContent = 'Options saved.';
-			setTimeout(function() { status.textContent = ''; }, 750);
-		});
+		modified = true;
 	}
 	else
 	{
 		log("Got an invalid option, not saving: " + overrideOption, MESSAGE_TYPES.ERROR);
 	}
+	
+	let sortOverrideOption = getSelectedSortOverrideOption();
+
+	if(isSortOverrideOptionValid(sortOverrideOption))
+	{
+		optionKey[STORAGE_KEYS.SORT_OVERRIDE_OPTION] = sortOverrideOption;	
+		modified = true;
+	}
+	else
+	{
+		log("Got an invalid sort option, not saving: " + sortOverrideOption, MESSAGE_TYPES.ERROR);
+	}
+
+	if (modified)
+		chrome.storage.sync.set(optionKey, function() {
+		let status = document.getElementById('status');
+		status.textContent = 'Options saved.';
+		setTimeout(function() { status.textContent = ''; }, 750);
+	});
 }
 
 function getSelectedOverrideOption()
@@ -65,6 +95,32 @@ function getSelectedOverrideOption()
 	}
 }
 
+
+function getSelectedSortOverrideOption()
+{
+	if(isWidgetChecked(SORT_OVERRIDE_OPTIONS.BEST_RESULTS))
+	{
+		return SORT_OVERRIDE_OPTIONS.BEST_RESULTS;
+	}
+
+	if(isWidgetChecked(SORT_OVERRIDE_OPTIONS.CHEAPEST_WITH_DELIVERY_ONLY))
+	{
+		return SORT_OVERRIDE_OPTIONS.CHEAPEST_WITH_DELIVERY_ONLY;
+	}
+
+	if(isWidgetChecked(SORT_OVERRIDE_OPTIONS.NEWEST_FIRST))
+	{
+		return SORT_OVERRIDE_OPTIONS.NEWEST_FIRST;
+	}
+
+	if(isWidgetChecked(OVERRIDE_OPTIONS.DISABLE))
+	{
+		return SORT_OVERRIDE_OPTIONS.DISABLE;
+	}
+}
+
+
+
 function isWidgetChecked(widgetId)
 {
 	let widget = document.getElementById(widgetId);
@@ -87,3 +143,8 @@ document.getElementById(OVERRIDE_OPTIONS.COUNTRY_ONLY).addEventListener('click',
 document.getElementById(OVERRIDE_OPTIONS.CONTINENT_ONLY).addEventListener('click', saveOptions);
 document.getElementById(OVERRIDE_OPTIONS.CONTINENTAL_REGION_ONLY).addEventListener('click', saveOptions);
 document.getElementById(OVERRIDE_OPTIONS.DISABLE).addEventListener('click',  saveOptions);
+
+document.getElementById(SORT_OVERRIDE_OPTIONS.BEST_RESULTS).addEventListener('click', saveOptions);
+document.getElementById(SORT_OVERRIDE_OPTIONS.CHEAPEST_WITH_DELIVERY_ONLY).addEventListener('click', saveOptions);
+document.getElementById(SORT_OVERRIDE_OPTIONS.NEWEST_FIRST).addEventListener('click', saveOptions);
+document.getElementById(SORT_OVERRIDE_OPTIONS.DISABLE).addEventListener('click',  saveOptions);

--- a/extension/shared/constants.js
+++ b/extension/shared/constants.js
@@ -8,12 +8,22 @@ let OVERRIDE_OPTIONS =
 	DISABLE:  "disableRadioButton"
 };
 
+let SORT_OVERRIDE_OPTIONS =
+{
+	CHEAPEST_WITH_DELIVERY_ONLY: "sortOrderCheapestIncludingDeliveryRadioButton",
+	NEWEST_FIRST: "sortOrderNewRadioButton",
+	BEST_RESULTS: "sortOrderBestResultsRadioButton",
+	DISABLE:  "sortOrderDisableRadioButton"
+};
+
 let STORAGE_KEYS =
 {
-	OVERRIDE_OPTION: "overrideOption"
+	OVERRIDE_OPTION: "overrideOption",
+	SORT_OVERRIDE_OPTION: "sortOverrideOption"
 };
 
 let defaultOverride = OVERRIDE_OPTIONS.COUNTRY_ONLY;
+let defaultSortOverride = SORT_OVERRIDE_OPTIONS.CHEAPEST_WITH_DELIVERY_ONLY;
 
 let MESSAGE_TYPES =
 {
@@ -34,9 +44,14 @@ let EBAY_URL_IDENTIFIER = "www.ebay.";
 let EBAY_SEARCH_IDENTIFIER = "/sch/";
 let EBAY_BROWSE_IDENTIFIER = "/bn_";
 let EBAY_LOCATION_IDENTIFIER = "LH_PrefLoc";
+let EBAY_SORT_IDENTIFIER = "_sop"; // 16
 let COUNTRY_LOCATION_VALUE = "1";
 let CONTINENT_LOCATION_VALUE = "3";
 let CONTINENT_REGION_LOCATION_VALUE = "6";
+let SORT_BEST_RESULTS_VALUE = "12";
+let SORT_WITH_DEVLIVERY_DESCENDING_VALUE = "15";
+let SORT_NEW_VALUE = "10";
+let SORT_ENDING_SOON_VALUE = "1";
 let SEARCH_SECONDARY_DELIMITER = "&";
 let SEARCH_EQUAL_DELIMITER = "=";
 let SEARCH_ADVANCED_EQUAL_DELIMITER = "%";

--- a/extension/shared/utils.js
+++ b/extension/shared/utils.js
@@ -6,6 +6,14 @@ function isOverrideOptionValid(option)
 		    option === OVERRIDE_OPTIONS.DISABLE);
 }
 
+function isSortOverrideOptionValid(option)
+{
+	return (option === SORT_OVERRIDE_OPTIONS.BEST_RESULTS ||
+		    option === SORT_OVERRIDE_OPTIONS.CHEAPEST_WITH_DELIVERY_ONLY ||
+		    option === SORT_OVERRIDE_OPTIONS.NEWEST_FIRST ||
+		    option === SORT_OVERRIDE_OPTIONS.DISABLE);
+}
+
 function log(message, messageType)
 {
 	if(shouldLog === true) 
@@ -33,16 +41,37 @@ function log(message, messageType)
 function getOverrideOptionFromStorage(callBack)
 {
 	getStorage(function(items) {
-		callBack(items.overrideOption);
+		callBack(items.overrideOption, items.sortOverrideOption);
 	});
 }
 
-function saveOverrideOptionToStorage(overrideOption, callBack)
+function saveOverrideOptionToStorage(overrideOption, sortOverrideOption, callBack)
+{
+	setStorage(STORAGE_KEYS.OVERRIDE_OPTION, overrideOption, function(){
+		callBack();
+	});
+
+	setStorage(STORAGE_KEYS.SORT_OVERRIDE_OPTION, sortOverrideOption, function(){
+		callBack();
+	});
+}
+
+
+function saveLocationOverrideOptionToStorage(overrideOption, callBack)
 {
 	setStorage(STORAGE_KEYS.OVERRIDE_OPTION, overrideOption, function(){
 		callBack();
 	});
 }
+
+
+function saveSortOverrideOptionToStorage(sortOverrideOption, callBack)
+{
+	setStorage(STORAGE_KEYS.SORT_OVERRIDE_OPTION, sortOverrideOption, function(){
+		callBack();
+	});
+}
+
 
 function getStorage(callBack)
 {


### PR DESCRIPTION
Hi,

thanks for your great extension. :-)

I've missed this for years in ebay. 

And as I also missed setting sort order to include shipping by default, I extended your extension to allow also setting default sort order to some values.

Hope you like it - do with it what you like. My contribution is fully public domain - no rights reserved, so you don't even have to keep my name in it if you decided to merge it - I added it only to the manifest for myself in order to distinguish it from yours :-)

regards
